### PR TITLE
use a different split algorithm that does not ignore empty lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = {
                 // Return the html content
                 .then(function(content) {
                     if (range) {
-                        var lines = content.match(/[^\r\n]+/g);
+                        var lines = content.split(/\r?\n/);
                         lines = lines.slice(range.start, range.end);
                         content = lines.join('\n');
                     }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function rangeToLines(range) {
 
     return {
         start: Number(range[0]) - 1,
-        end: Number(range[1]) - 1
+        end: Number(range[1])
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var path = require('path');
 var request = require('request');
 
 function codeblock(language, content) {
-    return '<pre><code class="lang-' + language + '">' + content + '</code></pre>';
+    var cleaned = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return '<pre><code class="lang-' + language + '">' + cleaned + '</code></pre>';
 }
 
 // Convert a range to a {start,end} object

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gitbook-plugin-codesnippet",
     "description": "Easily include code snippets in your gitbook",
     "main": "index.js",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "engines": {
         "gitbook": ">=2.5.0"
     },

--- a/test/index.js
+++ b/test/index.js
@@ -97,7 +97,28 @@ describe('codesnippet', function() {
                 gitbook: pkg.engines.gitbook,
                 "plugins": ["codesnippet"]
             })
-            .withFile('myfile.js', 'test\ntest 2\ntest 3\ntest 4')
+            .withFile('myfile.js', 'test\ntest 2\ntest 3\ntest 4\ntest5')
+            .create()
+            .then(function(result) {
+                var index = result.get('index.html');
+                var $ = index.$;
+
+                var codeBlock = $('code[class="lang-js"]');
+
+                assert.equal(codeBlock.length, 1);
+                assert.equal(codeBlock.text(), 'test 2\ntest 3');
+            });
+    });
+
+    it('should slice empty lines', function() {
+        return tester.builder()
+            .withContent('#test me\n\n{% codesnippet "./myfile.js", lines="4:6" %}{% endcodesnippet %}')
+            .withLocalPlugin(path.join(__dirname, '..'))
+            .withBookJson({
+                gitbook: pkg.engines.gitbook,
+                "plugins": ["codesnippet"]
+            })
+            .withFile('myfile.js', 'test\n\n\ntest 2\ntest 3\ntest 4\ntest5')
             .create()
             .then(function(result) {
                 var index = result.get('index.html');


### PR DESCRIPTION
The current version does not count empty lines of code when using the lines parameter.

I am not able to run the mocha tests. I get a build error on the 'lines' test cases. The error happens in Nunjucks during the template compilation within gitbook (version 3.1.1).

Solves this issue:
https://github.com/GitbookIO/plugin-codesnippet/issues/3
